### PR TITLE
Shift mobile adapt

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "cma-waveform-playlist",
   "description": "Multiple track web audio editor and player with waveform preview",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "main": "build/waveform-playlist.umd.js",
   "author": "Naomi Aro",
   "license": "MIT",

--- a/src/track/states/ShiftState.js
+++ b/src/track/states/ShiftState.js
@@ -11,6 +11,11 @@ export default class {
     this.sampleRate = sampleRate;
   }
 
+  getXOffsetOnTouchEvent(e) {
+    const bcr = e.target.getBoundingClientRect();
+    return e.targetTouches[0].clientX - bcr.x;
+  }
+
   emitShift(x) {
     const deltaX = x - this.prevX;
     const deltaTime = pixelsToSeconds(
@@ -35,10 +40,25 @@ export default class {
     this.prevX = e.offsetX;
   }
 
+  touchstart(e) {
+    e.preventDefault();
+
+    this.active = true;
+    this.el = e.target;
+    this.prevX = this.getXOffsetOnTouchEvent(e);
+  }
+
   mousemove(e) {
     if (this.active) {
       e.preventDefault();
       this.emitShift(e.offsetX);
+    }
+  }
+
+  touchmove(e) {
+    if (this.active) {
+      e.preventDefault();
+      this.emitShift(this.getXOffsetOnTouchEvent(e));
     }
   }
 
@@ -56,11 +76,26 @@ export default class {
     }
   }
 
+  touchend(e) {
+    if (this.active) {
+      e.preventDefault();
+      this.complete(this.getXOffsetOnTouchEvent(e));
+    }
+  }
+
   static getClass() {
     return ".state-shift";
   }
 
   static getEvents() {
-    return ["mousedown", "mousemove", "mouseup", "mouseleave"];
+    return [
+      "mousedown",
+      "mousemove",
+      "mouseup",
+      "mouseleave",
+      "touchstart",
+      "touchmove",
+      "touchend",
+    ];
   }
 }


### PR DESCRIPTION
Currently, the editor's SHIFT event does not work with touch events. This PR aims to add the touchstart, touchmove, and touchend events to this functionality.