### PR TITLE
Select mobile adapt

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "cma-waveform-playlist",
   "description": "Multiple track web audio editor and player with waveform preview",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "main": "build/waveform-playlist.umd.js",
   "author": "Naomi Aro",
   "license": "MIT",

--- a/src/track/states/SelectState.js
+++ b/src/track/states/SelectState.js
@@ -1,4 +1,5 @@
 import { pixelsToSeconds } from "../../utils/conversions";
+import { getXOffsetOnTouchEvent } from "../../utils/mobiles";
 
 export default class {
   constructor(track) {
@@ -47,10 +48,31 @@ export default class {
     this.track.ee.emit("select", startTime, startTime, this.track);
   }
 
+  touchstart(e) {
+    e.preventDefault();
+    this.active = true;
+
+    this.startX = getXOffsetOnTouchEvent(e);
+    const startTime = pixelsToSeconds(
+      this.startX,
+      this.samplesPerPixel,
+      this.sampleRate
+    );
+
+    this.track.ee.emit("select", startTime, startTime, this.track);
+  }
+
   mousemove(e) {
     if (this.active) {
       e.preventDefault();
       this.emitSelection(e.offsetX);
+    }
+  }
+
+  touchmove(e) {
+    if (this.active) {
+      e.preventDefault();
+      this.emitSelection(getXOffsetOnTouchEvent(e));
     }
   }
 
@@ -68,11 +90,26 @@ export default class {
     }
   }
 
+  touchend(e) {
+    if (this.active) {
+      e.preventDefault();
+      this.complete(getXOffsetOnTouchEvent(e));
+    }
+  }
+
   static getClass() {
     return ".state-select";
   }
 
   static getEvents() {
-    return ["mousedown", "mousemove", "mouseup", "mouseleave"];
+    return [
+      "mousedown",
+      "mousemove",
+      "mouseup",
+      "mouseleave",
+      "touchstart",
+      "touchmove",
+      "touchend",
+    ];
   }
 }

--- a/src/track/states/ShiftState.js
+++ b/src/track/states/ShiftState.js
@@ -1,4 +1,5 @@
 import { pixelsToSeconds } from "../../utils/conversions";
+import { getXOffsetOnTouchEvent } from "../../utils/mobiles";
 
 export default class {
   constructor(track) {
@@ -9,11 +10,6 @@ export default class {
   setup(samplesPerPixel, sampleRate) {
     this.samplesPerPixel = samplesPerPixel;
     this.sampleRate = sampleRate;
-  }
-
-  getXOffsetOnTouchEvent(e) {
-    const bcr = e.target.getBoundingClientRect();
-    return e.targetTouches[0].clientX - bcr.x;
   }
 
   emitShift(x) {
@@ -45,7 +41,7 @@ export default class {
 
     this.active = true;
     this.el = e.target;
-    this.prevX = this.getXOffsetOnTouchEvent(e);
+    this.prevX = getXOffsetOnTouchEvent(e);
   }
 
   mousemove(e) {
@@ -58,7 +54,7 @@ export default class {
   touchmove(e) {
     if (this.active) {
       e.preventDefault();
-      this.emitShift(this.getXOffsetOnTouchEvent(e));
+      this.emitShift(getXOffsetOnTouchEvent(e));
     }
   }
 
@@ -79,7 +75,7 @@ export default class {
   touchend(e) {
     if (this.active) {
       e.preventDefault();
-      this.complete(this.getXOffsetOnTouchEvent(e));
+      this.complete(getXOffsetOnTouchEvent(e));
     }
   }
 

--- a/src/utils/mobiles.js
+++ b/src/utils/mobiles.js
@@ -1,0 +1,4 @@
+export function getXOffsetOnTouchEvent(e) {
+  const bcr = e.target.getBoundingClientRect();
+  return e.targetTouches[0].clientX - bcr.x;
+}


### PR DESCRIPTION
Currently, the editor's SELECT event does not work with touch events. This PR aims to add the touchstart, touchmove, and touchend events to this functionality.